### PR TITLE
Refactor/#8 지원 정보 entity 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 ## ERD
 
-![image](https://github.com/kawkmin/wanted-pre-onboarding-backend/assets/86940335/d97ebcd8-cf47-46c4-8ba8-94b56a11e0d3)
+![image](https://github.com/kawkmin/wanted-pre-onboarding-backend/assets/86940335/2a787849-5987-4ef6-abf2-9c7e916db1ae)
 
 ## 요구사항 구현 과정
 

--- a/src/main/java/com/wanted/wantedpreonboardingbackend/domain/matching/dao/MatchingRepository.java
+++ b/src/main/java/com/wanted/wantedpreonboardingbackend/domain/matching/dao/MatchingRepository.java
@@ -1,0 +1,8 @@
+package com.wanted.wantedpreonboardingbackend.domain.matching.dao;
+
+import com.wanted.wantedpreonboardingbackend.domain.matching.entity.Matching;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MatchingRepository extends JpaRepository<Matching, Long> {
+
+}

--- a/src/main/java/com/wanted/wantedpreonboardingbackend/domain/matching/entity/Matching.java
+++ b/src/main/java/com/wanted/wantedpreonboardingbackend/domain/matching/entity/Matching.java
@@ -1,0 +1,57 @@
+package com.wanted.wantedpreonboardingbackend.domain.matching.entity;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import com.wanted.wantedpreonboardingbackend.domain.recruit.entity.Recruit;
+import com.wanted.wantedpreonboardingbackend.domain.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 사용자가 지원한 채용공고에 관한 정보
+ */
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "t_matching")
+public class Matching {
+
+  //매칭 ID
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  @Column(name = "id", nullable = false)
+  private Long id;
+
+  //유저 (N:1)
+  @ManyToOne(fetch = LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  //채용공고 (N:1)
+  @ManyToOne(fetch = LAZY)
+  @JoinColumn(name = "recruit_id", nullable = false)
+  private Recruit recruit;
+
+  //지원 상태
+  @Enumerated(EnumType.STRING)
+  @Column(name = "state", nullable = false)
+  private StateEnum state;
+
+  /**
+   * 지원 상태를 관리하는 Eum
+   */
+  public enum StateEnum {
+    대기중, 불합격, 합격
+  }
+}

--- a/src/main/java/com/wanted/wantedpreonboardingbackend/domain/recruit/entity/Recruit.java
+++ b/src/main/java/com/wanted/wantedpreonboardingbackend/domain/recruit/entity/Recruit.java
@@ -4,7 +4,6 @@ import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 import com.wanted.wantedpreonboardingbackend.domain.company.entity.Company;
-import com.wanted.wantedpreonboardingbackend.domain.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -30,11 +29,6 @@ public class Recruit {
   @GeneratedValue(strategy = IDENTITY)
   @Column(name = "id", nullable = false)
   private Long id;
-
-  //유저 (N:1)
-  @ManyToOne(fetch = LAZY)
-  @JoinColumn(name = "user_id", nullable = false)
-  private User user;
 
   //회사 (N:1)
   @ManyToOne(fetch = LAZY)


### PR DESCRIPTION
## 🔥 Related Issue

close: #8 

## 📝 Description

사용자와 채용공고는 1:N로 하였지만, 다대다 관계였습니다.
다대다 관계는 다대다 사이의 정보가 없을 가능성이 낮아, 중간 엔티티를 설계하여, N:1 관계로 변경하는게 좋습니다.
정보의 예시로는, 사용자와 채용공고에 신청한 결과, 사용한 이력서, 시간 등이 있습니다.

## ⭐️ Review

주어진 것 외에도 생각하는 습관의 필요성을 느꼈습니다.